### PR TITLE
add custom error

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"task/internal/controller"
+	"task/internal/service"
+	"task/pkg/configuration"
+	"task/pkg/logger"
+	"task/pkg/webutils"
+)
+
+func main() {
+	config, err := configuration.LoadConfiguration()
+	if err != nil {
+		panic(err)
+	}
+	logger.Initialize(config.ConfigLogger)
+
+	e := webutils.NewEcho(config.ConfigEcho)
+	logger.Info().Msg("Finished configuration")
+
+	logger.Info().Msg("Starting services")
+
+	repository := service.NewRepository()
+	svc := service.NewService(repository)
+	controller.NewController(svc).RegisterRoutes(e)
+
+	webutils.StartEcho(e, config.AddressEcho)
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1,0 +1,69 @@
+package controller
+
+import (
+	"github.com/labstack/echo/v4"
+	"net/http"
+	"task/internal/dto"
+	"task/pkg/logger"
+	"task/pkg/utils"
+)
+
+type Controller struct {
+	service service
+}
+
+type service interface {
+	GetTask(int) (dto.GetTaskResponse, error)
+	CreateTask(dto.CreateTaskRequest) (dto.CreateTaskResponse, error)
+}
+
+func NewController(service service) *Controller {
+	if service == nil {
+		panic(service)
+	}
+	return &Controller{service: service}
+}
+
+func (c *Controller) RegisterRoutes(e *echo.Echo) {
+	g := e.Group("/task") // you could version the api here (e.g. api/v1/task) and use a middleware to check the token
+	g.GET("/:taskId", c.getTask)
+	g.POST("", c.createTask)
+}
+
+func (c *Controller) createTask(context echo.Context) error {
+	request := dto.CreateTaskRequest{}
+	err := context.Bind(&request)
+	if err != nil {
+		return err
+	}
+	err = context.Validate(request)
+	if err != nil {
+		return err
+	}
+	logger.Debug().Msgf("recived request: %+v", request)
+	createdTask, err := c.service.CreateTask(request)
+	if err != nil {
+		return err
+	}
+	logger.Debug().Msgf("created task %d", createdTask.ID)
+	return context.JSON(http.StatusOK, createdTask)
+}
+
+func (c *Controller) getTask(context echo.Context) error {
+	// I assume the task id is a number, because in a real application I would use a database,
+	// where the id is provided and it is a number
+
+	taskID, err := utils.GetEchoParamToInt(context, "taskId")
+	if err != nil {
+		return err
+	}
+
+	logger.Debug().Msgf("caller want task %d", taskID)
+
+	task, err := c.service.GetTask(taskID)
+	if err != nil {
+		return err
+	}
+	logger.Debug().Msgf("the task %d is : %+v", taskID, task)
+	return context.JSON(http.StatusOK, task)
+}

--- a/internal/dto/task.go
+++ b/internal/dto/task.go
@@ -1,0 +1,21 @@
+package dto
+
+type GetTaskResponse struct {
+	ID             int               `json:"id"`
+	Status         string            `json:"status"`
+	HTTPStatusCode int               `json:"httpStatusCode"`
+	Headers        map[string]string `json:"headers"` // use same convention as in the request
+	Length         int               `json:"length"`
+}
+
+type CreateTaskRequest struct {
+	Method string `json:"method" validate:"required"`
+	URL    string `json:"url" validate:"required"`
+	// Not a map[string][]string since in the file provided it wasn't written as an array.
+	// I assume multiple headers with the different values are separated by comma
+	Headers map[string]string `json:"headers"`
+}
+
+type CreateTaskResponse struct {
+	ID int `json:"id"`
+}

--- a/internal/service/models.go
+++ b/internal/service/models.go
@@ -1,0 +1,28 @@
+package service
+
+// to separate the entity for the repository from the dto of the request
+
+type AddTask struct {
+	Status string
+}
+
+type GetTask struct {
+	ID int
+	Task
+}
+
+type AddResponse struct {
+	ID             int
+	Status         string
+	HTTPStatusCode int
+	Headers        map[string][]string
+	Length         int
+}
+
+type Task struct {
+	Status         string
+	HTTPStatusCode int
+	Headers        map[string][]string
+	Length         int
+	Error          string // this field used only to keep track of the error message
+}

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"fmt"
+	"sync"
+	"task/pkg/customerror"
+	"task/pkg/logger"
+	"task/pkg/models"
+)
+
+type Repository struct {
+	mu                sync.Mutex
+	tasks             map[int]Task
+	lastTaskIDCreated int
+}
+
+func NewRepository() *Repository {
+	return &Repository{
+		mu:                sync.Mutex{},
+		tasks:             make(map[int]Task),
+		lastTaskIDCreated: 1, // start with value 1 for convenience
+	}
+}
+
+// AddTask adds a task to the repository and returns the ID of the task
+// in this case there are no errors, but the function signature was thought to be able to return an error
+// in case of using a database
+func (r *Repository) AddTask(status string) (result int, err error) {
+	// for concurrent access, it's critical to lock the map when accessing it to read or write
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.tasks[r.lastTaskIDCreated] = Task{
+		Status: status,
+	}
+	result = r.lastTaskIDCreated
+	r.lastTaskIDCreated++
+
+	return result, nil
+}
+
+func (r *Repository) GetTask(ID int) (GetTask, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	result, ok := r.tasks[ID]
+	if !ok { // you can also check if the id is greater than the lastTaskIDCreated
+		// codified error
+		return GetTask{}, customerror.NewI18nErrorWithParams(models.TaskIDNotFoundError, map[string]interface{}{
+			"taskId": ID,
+		})
+	}
+	return GetTask{ID: ID, Task: result}, nil
+}
+
+func (r *Repository) ChangeStatus(ID int, status string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	task, ok := r.tasks[ID]
+	if !ok {
+		logger.Error().Msgf("task with ID %d not found", ID)
+		return fmt.Errorf("task with ID %d not found", ID)
+	}
+	task.Status = status
+	r.tasks[ID] = task
+	return nil
+}
+
+func (r *Repository) AddResponse(response AddResponse) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	task, ok := r.tasks[response.ID]
+	if !ok {
+		logger.Error().Msgf("task with ID %d not found", response.ID)
+		return fmt.Errorf("task with ID %d not found", response.ID)
+	}
+	task.HTTPStatusCode = response.HTTPStatusCode
+	task.Headers = response.Headers
+	task.Length = response.Length
+	task.Status = response.Status
+	r.tasks[response.ID] = task
+	return nil
+}
+
+func (r *Repository) ChangeStatusInError(ID int, status string, err string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	task, ok := r.tasks[ID]
+	if !ok {
+		logger.Error().Msgf("task with ID %d not found", ID)
+		return fmt.Errorf("task with ID %d not found", ID)
+	}
+	task.Status = status
+	task.Error = err
+	r.tasks[ID] = task
+	return nil
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"task/internal/dto"
+	"task/pkg/logger"
+	"time"
+)
+
+// repository is an interface to the repository layer
+// in a real application this repository would be implemented with a database such as postgres using gorm as orm
+// since it is a simple application, I will use implement the repository to store information in memory on runtime
+// inevitably, this means that the data will be lost when the application is stopped
+type repository interface {
+	AddTask(status string) (int, error)
+	GetTask(ID int) (GetTask, error)
+	ChangeStatus(ID int, status string) error
+	AddResponse(response AddResponse) error
+	ChangeStatusInError(ID int, status string, err string) error
+}
+
+type Service struct {
+	repository repository
+}
+
+func NewService(repository repository) *Service {
+	if repository == nil {
+		panic(repository)
+	}
+	return &Service{
+		repository: repository,
+	}
+}
+
+const (
+	statusNew       = "new"
+	statusInProcess = "in_process"
+	statusDone      = "done"
+	statusError     = "error"
+
+	// timeoutHTTPRequest is the timeout for the http request could be a configuration parameter in the file env
+	timeoutHTTPRequest = 10 * time.Second
+)
+
+func (s *Service) GetTask(taskID int) (dto.GetTaskResponse, error) {
+	task, err := s.repository.GetTask(taskID)
+	if err != nil {
+		return dto.GetTaskResponse{}, err
+	}
+	return dto.GetTaskResponse{
+		ID:             task.ID,
+		Status:         task.Status,
+		HTTPStatusCode: task.HTTPStatusCode,
+		Headers:        transformHeaders(task.Headers),
+		Length:         task.Length,
+	}, nil
+}
+
+func transformHeaders(headers map[string][]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	result := make(map[string]string)
+	for k, v := range headers {
+		result[k] = strings.Join(v, ",")
+	}
+	return result
+}
+
+func (s *Service) CreateTask(request dto.CreateTaskRequest) (dto.CreateTaskResponse, error) {
+	taskID, err := s.repository.AddTask(statusNew)
+	if err != nil {
+		return dto.CreateTaskResponse{}, err
+	}
+
+	go func() {
+		s.makeRequest(taskID, request)
+	}()
+
+	return dto.CreateTaskResponse{
+		ID: taskID,
+	}, nil
+}
+
+func (s *Service) makeRequest(taskID int, request dto.CreateTaskRequest) {
+	err := s.repository.ChangeStatus(taskID, statusInProcess)
+	if err != nil {
+		s.changeStatusToError(taskID, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutHTTPRequest)
+	defer cancel() // cancel whenever the function returns
+
+	req, err := http.NewRequestWithContext(ctx, request.Method, request.URL, nil)
+	if err != nil {
+		logger.Error().Msgf("failed to create request for task %d, err= %v", taskID, err)
+
+		s.changeStatusToError(taskID, err)
+		return
+	}
+
+	for k, v := range request.Headers {
+		values := strings.Split(v, ",") // I will use this to handle the case where the same header is provided with different values
+		req.Header[k] = values
+		logger.Debug().Msgf("header %s: %v", k, values)
+	}
+
+	client := http.Client{Timeout: timeoutHTTPRequest}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Error().Msgf("failed to make request for task %d, err= %v", taskID, err)
+
+		s.changeStatusToError(taskID, err)
+		return
+	}
+
+	err = s.repository.AddResponse(AddResponse{
+		ID:             taskID,
+		Status:         statusDone,
+		HTTPStatusCode: resp.StatusCode,
+		Headers:        resp.Header,
+		Length:         int(resp.ContentLength),
+	})
+	if err != nil {
+		logger.Error().Msgf("failed to add response for task %d, err= %v", taskID, err)
+
+		s.changeStatusToError(taskID, err)
+	}
+	return
+}
+
+func (s *Service) changeStatusToError(taskID int, errToSave error) {
+	err := s.repository.ChangeStatusInError(taskID, statusError, errToSave.Error())
+	if err != nil {
+		logger.Error().Err(err).Msgf("failed to change status of task %d to error", taskID)
+	}
+	return
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,376 @@
+package service
+
+import (
+	"github.com/go-test/deep"
+	"maps"
+	"net/http"
+	"reflect"
+	"sync"
+	"task/internal/dto"
+	"task/pkg/customerror"
+	"task/pkg/logger"
+	"task/pkg/models"
+	"testing"
+)
+
+func TestService_CreateTask(t *testing.T) {
+	logger.InitializeForTest()
+
+	// Important: this test mut be executed in cascade
+	// because the repository is a global variable
+	s := NewService(NewRepository())
+	type args struct {
+		request dto.CreateTaskRequest
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		want      dto.CreateTaskResponse
+		wantErr   bool
+		checkFunc func(t *testing.T, s *Service)
+	}{
+		{
+			name: "create first task",
+			args: args{
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			want: dto.CreateTaskResponse{
+				ID: 1,
+			},
+		},
+		{
+			name: "create second task",
+			args: args{
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			want: dto.CreateTaskResponse{
+				ID: 2,
+			},
+		},
+		{
+			name: "create third task",
+			args: args{
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			want: dto.CreateTaskResponse{
+				ID: 3,
+			},
+		},
+		{
+			name: "stress test",
+			args: args{
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			want: dto.CreateTaskResponse{
+				ID: 4,
+			},
+			checkFunc: func(t *testing.T, s *Service) {
+				sg := sync.WaitGroup{}
+				for i := 0; i < 100; i++ {
+					sg.Add(1)
+					go func() {
+						defer sg.Done()
+						_, _ = s.CreateTask(dto.CreateTaskRequest{
+							Method: "GET",
+							URL:    "googlassadse",
+						})
+					}()
+				}
+				sg.Wait()
+				_, err := s.GetTask(104)
+				if err != nil {
+					t.Errorf("error getting task with id %d", 104)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.CreateTask(tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateTask() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateTask() got = %v, want %v", got, tt.want)
+			}
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, s)
+			}
+		})
+	}
+}
+
+func TestService_GetTask(t *testing.T) {
+	logger.InitializeForTest()
+	initialMap := map[int]Task{
+		1: {
+			Status: statusNew,
+		},
+		2: {
+			Status: statusInProcess,
+		},
+		3: {
+			Status:         statusDone,
+			HTTPStatusCode: http.StatusOK,
+			Headers: map[string][]string{
+				"Content-Type": {"application/json,application/xml"},
+				"Accept":       {"application/json"},
+			},
+			Length: 20,
+			Error:  "",
+		},
+		4: {
+			Status: statusError,
+			Error:  "incorrect url",
+		},
+	}
+	s := NewService(&Repository{
+		mu:                sync.Mutex{},
+		tasks:             initialMap,
+		lastTaskIDCreated: len(initialMap),
+	})
+	type args struct {
+		taskID int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    dto.GetTaskResponse
+		wantErr error
+	}{
+		{
+			name: "response with correct status",
+			args: args{
+				taskID: 1,
+			},
+			want: dto.GetTaskResponse{
+				ID:     1,
+				Status: statusNew,
+			},
+		},
+		{
+			name: "response with in process status",
+			args: args{
+				taskID: 2,
+			},
+			want: dto.GetTaskResponse{
+				ID:     2,
+				Status: statusInProcess,
+			},
+		},
+		{
+			name: "response with multiple headers",
+			args: args{
+				taskID: 3,
+			},
+			want: dto.GetTaskResponse{
+				ID:             3,
+				Status:         statusDone,
+				HTTPStatusCode: http.StatusOK,
+				Headers: map[string]string{
+					"Content-Type": "application/json,application/xml",
+					"Accept":       "application/json",
+				},
+			},
+		},
+		{
+			name: "response with error",
+			args: args{
+				taskID: 4,
+			},
+			want: dto.GetTaskResponse{
+				ID:     4,
+				Status: statusError,
+			},
+		},
+		{
+			name: "test with incorrect taskID",
+			args: args{
+				taskID: 5,
+			},
+			want: dto.GetTaskResponse{},
+			wantErr: customerror.NewI18nErrorWithParams(models.TaskIDNotFoundError, map[string]interface{}{
+				"taskId": 5,
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.GetTask(tt.args.taskID)
+			if diff := deep.Equal(err, tt.wantErr); diff != nil {
+				t.Errorf("GetTask() error = %v, wantErr %v, diff %v", err, tt.wantErr, diff)
+				return
+			}
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("GetTask() got = %v, want %v, diff %v", got, tt.want, diff)
+			}
+		})
+	}
+}
+
+func TestService_makeRequest(t *testing.T) {
+	logger.InitializeForTest()
+
+	initialMap := map[int]Task{
+		1: {
+			Status: statusNew,
+		},
+	}
+	type fields struct {
+		repository repository
+	}
+	type args struct {
+		taskID  int
+		request dto.CreateTaskRequest
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		checkFunc func(t *testing.T, task GetTask)
+	}{
+		{
+			name: "test with incorrect method",
+			fields: fields{repository: &Repository{
+				mu:                sync.Mutex{},
+				tasks:             maps.Clone(initialMap),
+				lastTaskIDCreated: len(initialMap),
+			}},
+			args: args{
+				taskID: 1,
+				request: dto.CreateTaskRequest{
+					Method: "try",
+					URL:    "http://www.google.com",
+				},
+			},
+			checkFunc: func(t *testing.T, task GetTask) {
+				if task.Status != statusDone {
+					t.Errorf("task status = %v, want %v", task.Status, statusDone)
+				}
+				if task.HTTPStatusCode != http.StatusMethodNotAllowed {
+					t.Errorf("task HTTPStatusCode = %v, want %v", task.HTTPStatusCode, http.StatusMethodNotAllowed)
+				}
+			},
+		},
+		{
+			name: "test with incorrect url",
+			fields: fields{repository: &Repository{
+				mu:                sync.Mutex{},
+				tasks:             maps.Clone(initialMap),
+				lastTaskIDCreated: len(initialMap),
+			}},
+			args: args{
+				taskID: 1,
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://wwwww.google.com",
+				},
+			},
+			checkFunc: func(t *testing.T, task GetTask) {
+				if task.Status != statusError {
+					t.Errorf("task status = %v, want %v", task.Status, statusError)
+				}
+			},
+		},
+		{
+			name: "test with correct request",
+			fields: fields{repository: &Repository{
+				mu:                sync.Mutex{},
+				tasks:             maps.Clone(initialMap),
+				lastTaskIDCreated: len(initialMap),
+			}},
+			args: args{
+				taskID: 1,
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			checkFunc: func(t *testing.T, task GetTask) {
+				if task.Status != statusDone {
+					t.Errorf("task status = %v, want %v", task.Status, statusDone)
+				}
+				if task.HTTPStatusCode != http.StatusOK {
+					t.Errorf("task HTTPStatusCode = %v, want %v", task.HTTPStatusCode, http.StatusOK)
+				}
+				if task.Error != "" {
+					t.Errorf("task Error = %v, want %v", task.Error, "")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				repository: tt.fields.repository,
+			}
+			s.makeRequest(tt.args.taskID, tt.args.request)
+			if tt.checkFunc != nil {
+				task, err := s.repository.GetTask(tt.args.taskID)
+				if err != nil {
+					t.Errorf("error getting task with id %d", tt.args.taskID)
+				}
+				tt.checkFunc(t, task)
+			}
+		})
+	}
+}
+
+func Test_transformHeaders(t *testing.T) {
+	logger.InitializeForTest()
+	type args struct {
+		headers map[string][]string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantResult map[string]string
+	}{
+		{
+			name: "test without multiple values",
+			args: args{
+				headers: map[string][]string{
+					"Content-Type": {"application/json"},
+					"Accept":       {"application/json"},
+				}},
+			wantResult: map[string]string{
+				"Content-Type": "application/json",
+				"Accept":       "application/json",
+			},
+		},
+		{
+			name: "test with multiple values",
+			args: args{
+				headers: map[string][]string{
+					"Content-Type": {"application/json", "application/xml"},
+					"Accept":       {"application/json"},
+				}},
+			wantResult: map[string]string{
+				"Content-Type": "application/json,application/xml",
+				"Accept":       "application/json",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotResult := transformHeaders(tt.args.headers); !reflect.DeepEqual(gotResult, tt.wantResult) {
+				t.Errorf("transformHeaders() = %v, want %v", gotResult, tt.wantResult)
+			}
+
+		})
+	}
+}

--- a/pkg/customerror/customerror.go
+++ b/pkg/customerror/customerror.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/labstack/echo/v4"
-	"task/pkg/logger"
 )
 
 const (
@@ -37,8 +36,6 @@ func NewI18nErrorWithParams(code string, params map[string]interface{}) *CustomE
 }
 
 func ErrorHandler(err error, c echo.Context) {
-	logger.Error().Err(err).Msgf("Error occurred in request %s %s", c.Request().Method, c.Request().URL)
-
 	var customError *CustomError
 	if errors.As(err, &customError) {
 		_ = c.JSON(customError.HttpCode, customError)

--- a/pkg/customerror/customerror.go
+++ b/pkg/customerror/customerror.go
@@ -1,0 +1,59 @@
+package customerror
+
+import (
+	"errors"
+	"fmt"
+	"github.com/labstack/echo/v4"
+	"task/pkg/logger"
+)
+
+const (
+	customErrorType      = "ERROR"
+	DefaultHttpErrorCode = 400
+)
+
+type CustomError struct {
+	Code     string                 `json:"code,omitempty"`
+	HttpCode int                    `json:"httpCode"`
+	Params   map[string]interface{} `json:"params,omitempty"`
+	Type     string                 `json:"type"`
+}
+
+func NewCustomError(code string) *CustomError {
+	return &CustomError{
+		Code:     code,
+		HttpCode: DefaultHttpErrorCode,
+		Type:     customErrorType,
+	}
+}
+
+func NewI18nErrorWithParams(code string, params map[string]interface{}) *CustomError {
+	return &CustomError{
+		Code:     code,
+		Params:   params,
+		HttpCode: DefaultHttpErrorCode,
+		Type:     customErrorType,
+	}
+}
+
+func ErrorHandler(err error, c echo.Context) {
+	logger.Error().Err(err).Msgf("Error occurred in request %s %s", c.Request().Method, c.Request().URL)
+
+	var customError *CustomError
+	if errors.As(err, &customError) {
+		_ = c.JSON(customError.HttpCode, customError)
+		return
+	}
+	var errorHTTP *echo.HTTPError
+	if errors.As(err, &errorHTTP) {
+		_ = c.JSON(errorHTTP.Code, errorHTTP)
+		return
+	}
+	_ = c.JSON(DefaultHttpErrorCode, map[string]interface{}{
+		"message": err.Error(),
+	})
+}
+
+func (c *CustomError) Error() string {
+	return fmt.Sprintf("CustomError code: %v, params: %v, httpCode: %v", c.Code, c.Params, c.HttpCode)
+}

--- a/pkg/logger/test.go
+++ b/pkg/logger/test.go
@@ -1,0 +1,15 @@
+package logger
+
+import (
+	"task/pkg/configuration"
+)
+
+func InitializeForTest() {
+	if internalLogger != nil {
+		return
+	}
+	Initialize(configuration.ConfigLogger{
+		LogLevel:    "trace",
+		LogSaveFile: false,
+	})
+}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -1,0 +1,5 @@
+package models
+
+const (
+	TaskIDNotFoundError = "TASK_ID_NOT_FOUND_ERROR"
+)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/labstack/echo/v4"
+	"strconv"
+)
+
+func GetEchoParamToInt(contex echo.Context, param string) (int, error) {
+	value := contex.Param(param)
+	if value == "" {
+		return -1, fmt.Errorf("missing param %s", param)
+	}
+	result, err := strconv.Atoi(value)
+	if err != nil {
+		return -1, err
+	}
+	return result, nil
+}

--- a/pkg/webutils/webutils.go
+++ b/pkg/webutils/webutils.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"task/pkg/configuration"
+	"task/pkg/customerror"
 	"task/pkg/logger"
 )
 
@@ -30,6 +31,7 @@ func NewEcho(config configuration.ConfigEcho) *echo.Echo {
 
 	e.HideBanner = true
 
+	e.HTTPErrorHandler = customerror.ErrorHandler
 	logger.Info().Msg("Finished echo initialization")
 	return e
 }


### PR DESCRIPTION
Context:
This set of changes introduces a new file for a custom error handler. The purpose is to provide standardized errors, fostering a consistent approach to error messaging across server calls. This is particularly beneficial for achieving a level of standardization similar to internationalization (i18n).

Previously:
- PR 5: add echo web framework (https://github.com/RachidEddahaPrivate/task-golang/pull/5)

In this PR:
This iteration adds a new file dedicated to a custom error handler. The goal is to enhance the consistency of error messages across server calls, providing a standardized approach similar to internationalization (i18n). T

Risk:
There are no risk

How to revert:
Remove this code.

Testing:
To test these changes, instantiate an Echo HTTP server, create a route that returns a custom error, and verify that it is received as expected. 