### PR TITLE
add repository to store information

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"task/internal/controller"
+	"task/internal/service"
+	"task/pkg/configuration"
+	"task/pkg/logger"
+	"task/pkg/webutils"
+)
+
+func main() {
+	config, err := configuration.LoadConfiguration()
+	if err != nil {
+		panic(err)
+	}
+	logger.Initialize(config.ConfigLogger)
+
+	e := webutils.NewEcho(config.ConfigEcho)
+	logger.Info().Msg("Finished configuration")
+
+	logger.Info().Msg("Starting services")
+
+	repository := service.NewRepository()
+	svc := service.NewService(repository)
+	controller.NewController(svc).RegisterRoutes(e)
+
+	webutils.StartEcho(e, config.AddressEcho)
+}

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"fmt"
+	"sync"
+	"task/pkg/customerror"
+	"task/pkg/logger"
+	"task/pkg/models"
+)
+
+type Repository struct {
+	mu                sync.Mutex
+	tasks             map[int]Task
+	lastTaskIDCreated int
+}
+
+func NewRepository() *Repository {
+	return &Repository{
+		mu:                sync.Mutex{},
+		tasks:             make(map[int]Task),
+		lastTaskIDCreated: 1, // start with value 1 for convenience
+	}
+}
+
+// AddTask adds a task to the repository and returns the ID of the task
+// in this case there are no errors, but the function signature was thought to be able to return an error
+// in case of using a database
+func (r *Repository) AddTask(status string) (result int, err error) {
+	// for concurrent access, it's critical to lock the map when accessing it to read or write
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.tasks[r.lastTaskIDCreated] = Task{
+		Status: status,
+	}
+	result = r.lastTaskIDCreated
+	r.lastTaskIDCreated++
+
+	return result, nil
+}
+
+func (r *Repository) GetTask(ID int) (GetTask, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	result, ok := r.tasks[ID]
+	if !ok { // you can also check if the id is greater than the lastTaskIDCreated
+		// codified error
+		return GetTask{}, customerror.NewI18nErrorWithParams(models.TaskIDNotFoundError, map[string]interface{}{
+			"taskId": ID,
+		})
+	}
+	return GetTask{ID: ID, Task: result}, nil
+}
+
+func (r *Repository) ChangeStatus(ID int, status string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	task, ok := r.tasks[ID]
+	if !ok {
+		logger.Error().Msgf("task with ID %d not found", ID)
+		return fmt.Errorf("task with ID %d not found", ID)
+	}
+	task.Status = status
+	r.tasks[ID] = task
+	return nil
+}
+
+func (r *Repository) AddResponse(response AddResponse) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	task, ok := r.tasks[response.ID]
+	if !ok {
+		logger.Error().Msgf("task with ID %d not found", response.ID)
+		return fmt.Errorf("task with ID %d not found", response.ID)
+	}
+	task.HTTPStatusCode = response.HTTPStatusCode
+	task.Headers = response.Headers
+	task.Length = response.Length
+	task.Status = response.Status
+	r.tasks[response.ID] = task
+	return nil
+}
+
+func (r *Repository) ChangeStatusInError(ID int, status string, err string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	task, ok := r.tasks[ID]
+	if !ok {
+		logger.Error().Msgf("task with ID %d not found", ID)
+		return fmt.Errorf("task with ID %d not found", ID)
+	}
+	task.Status = status
+	task.Error = err
+	r.tasks[ID] = task
+	return nil
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,376 @@
+package service
+
+import (
+	"github.com/go-test/deep"
+	"maps"
+	"net/http"
+	"reflect"
+	"sync"
+	"task/internal/dto"
+	"task/pkg/customerror"
+	"task/pkg/logger"
+	"task/pkg/models"
+	"testing"
+)
+
+func TestService_CreateTask(t *testing.T) {
+	logger.InitializeForTest()
+
+	// Important: this test mut be executed in cascade
+	// because the repository is a global variable
+	s := NewService(NewRepository())
+	type args struct {
+		request dto.CreateTaskRequest
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		want      dto.CreateTaskResponse
+		wantErr   bool
+		checkFunc func(t *testing.T, s *Service)
+	}{
+		{
+			name: "create first task",
+			args: args{
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			want: dto.CreateTaskResponse{
+				ID: 1,
+			},
+		},
+		{
+			name: "create second task",
+			args: args{
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			want: dto.CreateTaskResponse{
+				ID: 2,
+			},
+		},
+		{
+			name: "create third task",
+			args: args{
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			want: dto.CreateTaskResponse{
+				ID: 3,
+			},
+		},
+		{
+			name: "stress test",
+			args: args{
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			want: dto.CreateTaskResponse{
+				ID: 4,
+			},
+			checkFunc: func(t *testing.T, s *Service) {
+				sg := sync.WaitGroup{}
+				for i := 0; i < 100; i++ {
+					sg.Add(1)
+					go func() {
+						defer sg.Done()
+						_, _ = s.CreateTask(dto.CreateTaskRequest{
+							Method: "GET",
+							URL:    "googlassadse",
+						})
+					}()
+				}
+				sg.Wait()
+				_, err := s.GetTask(104)
+				if err != nil {
+					t.Errorf("error getting task with id %d", 104)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.CreateTask(tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateTask() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateTask() got = %v, want %v", got, tt.want)
+			}
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, s)
+			}
+		})
+	}
+}
+
+func TestService_GetTask(t *testing.T) {
+	logger.InitializeForTest()
+	initialMap := map[int]Task{
+		1: {
+			Status: statusNew,
+		},
+		2: {
+			Status: statusInProcess,
+		},
+		3: {
+			Status:         statusDone,
+			HTTPStatusCode: http.StatusOK,
+			Headers: map[string][]string{
+				"Content-Type": {"application/json,application/xml"},
+				"Accept":       {"application/json"},
+			},
+			Length: 20,
+			Error:  "",
+		},
+		4: {
+			Status: statusError,
+			Error:  "incorrect url",
+		},
+	}
+	s := NewService(&Repository{
+		mu:                sync.Mutex{},
+		tasks:             initialMap,
+		lastTaskIDCreated: len(initialMap),
+	})
+	type args struct {
+		taskID int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    dto.GetTaskResponse
+		wantErr error
+	}{
+		{
+			name: "response with correct status",
+			args: args{
+				taskID: 1,
+			},
+			want: dto.GetTaskResponse{
+				ID:     1,
+				Status: statusNew,
+			},
+		},
+		{
+			name: "response with in process status",
+			args: args{
+				taskID: 2,
+			},
+			want: dto.GetTaskResponse{
+				ID:     2,
+				Status: statusInProcess,
+			},
+		},
+		{
+			name: "response with multiple headers",
+			args: args{
+				taskID: 3,
+			},
+			want: dto.GetTaskResponse{
+				ID:             3,
+				Status:         statusDone,
+				HTTPStatusCode: http.StatusOK,
+				Headers: map[string]string{
+					"Content-Type": "application/json,application/xml",
+					"Accept":       "application/json",
+				},
+			},
+		},
+		{
+			name: "response with error",
+			args: args{
+				taskID: 4,
+			},
+			want: dto.GetTaskResponse{
+				ID:     4,
+				Status: statusError,
+			},
+		},
+		{
+			name: "test with incorrect taskID",
+			args: args{
+				taskID: 5,
+			},
+			want: dto.GetTaskResponse{},
+			wantErr: customerror.NewI18nErrorWithParams(models.TaskIDNotFoundError, map[string]interface{}{
+				"taskId": 5,
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.GetTask(tt.args.taskID)
+			if diff := deep.Equal(err, tt.wantErr); diff != nil {
+				t.Errorf("GetTask() error = %v, wantErr %v, diff %v", err, tt.wantErr, diff)
+				return
+			}
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("GetTask() got = %v, want %v, diff %v", got, tt.want, diff)
+			}
+		})
+	}
+}
+
+func TestService_makeRequest(t *testing.T) {
+	logger.InitializeForTest()
+
+	initialMap := map[int]Task{
+		1: {
+			Status: statusNew,
+		},
+	}
+	type fields struct {
+		repository repository
+	}
+	type args struct {
+		taskID  int
+		request dto.CreateTaskRequest
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		checkFunc func(t *testing.T, task GetTask)
+	}{
+		{
+			name: "test with incorrect method",
+			fields: fields{repository: &Repository{
+				mu:                sync.Mutex{},
+				tasks:             maps.Clone(initialMap),
+				lastTaskIDCreated: len(initialMap),
+			}},
+			args: args{
+				taskID: 1,
+				request: dto.CreateTaskRequest{
+					Method: "try",
+					URL:    "http://www.google.com",
+				},
+			},
+			checkFunc: func(t *testing.T, task GetTask) {
+				if task.Status != statusDone {
+					t.Errorf("task status = %v, want %v", task.Status, statusDone)
+				}
+				if task.HTTPStatusCode != http.StatusMethodNotAllowed {
+					t.Errorf("task HTTPStatusCode = %v, want %v", task.HTTPStatusCode, http.StatusMethodNotAllowed)
+				}
+			},
+		},
+		{
+			name: "test with incorrect url",
+			fields: fields{repository: &Repository{
+				mu:                sync.Mutex{},
+				tasks:             maps.Clone(initialMap),
+				lastTaskIDCreated: len(initialMap),
+			}},
+			args: args{
+				taskID: 1,
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://wwwww.google.com",
+				},
+			},
+			checkFunc: func(t *testing.T, task GetTask) {
+				if task.Status != statusError {
+					t.Errorf("task status = %v, want %v", task.Status, statusError)
+				}
+			},
+		},
+		{
+			name: "test with correct request",
+			fields: fields{repository: &Repository{
+				mu:                sync.Mutex{},
+				tasks:             maps.Clone(initialMap),
+				lastTaskIDCreated: len(initialMap),
+			}},
+			args: args{
+				taskID: 1,
+				request: dto.CreateTaskRequest{
+					Method: "GET",
+					URL:    "http://www.google.com",
+				},
+			},
+			checkFunc: func(t *testing.T, task GetTask) {
+				if task.Status != statusDone {
+					t.Errorf("task status = %v, want %v", task.Status, statusDone)
+				}
+				if task.HTTPStatusCode != http.StatusOK {
+					t.Errorf("task HTTPStatusCode = %v, want %v", task.HTTPStatusCode, http.StatusOK)
+				}
+				if task.Error != "" {
+					t.Errorf("task Error = %v, want %v", task.Error, "")
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				repository: tt.fields.repository,
+			}
+			s.makeRequest(tt.args.taskID, tt.args.request)
+			if tt.checkFunc != nil {
+				task, err := s.repository.GetTask(tt.args.taskID)
+				if err != nil {
+					t.Errorf("error getting task with id %d", tt.args.taskID)
+				}
+				tt.checkFunc(t, task)
+			}
+		})
+	}
+}
+
+func Test_transformHeaders(t *testing.T) {
+	logger.InitializeForTest()
+	type args struct {
+		headers map[string][]string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantResult map[string]string
+	}{
+		{
+			name: "test without multiple values",
+			args: args{
+				headers: map[string][]string{
+					"Content-Type": {"application/json"},
+					"Accept":       {"application/json"},
+				}},
+			wantResult: map[string]string{
+				"Content-Type": "application/json",
+				"Accept":       "application/json",
+			},
+		},
+		{
+			name: "test with multiple values",
+			args: args{
+				headers: map[string][]string{
+					"Content-Type": {"application/json", "application/xml"},
+					"Accept":       {"application/json"},
+				}},
+			wantResult: map[string]string{
+				"Content-Type": "application/json,application/xml",
+				"Accept":       "application/json",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotResult := transformHeaders(tt.args.headers); !reflect.DeepEqual(gotResult, tt.wantResult) {
+				t.Errorf("transformHeaders() = %v, want %v", gotResult, tt.wantResult)
+			}
+
+		})
+	}
+}

--- a/pkg/logger/test.go
+++ b/pkg/logger/test.go
@@ -1,0 +1,15 @@
+package logger
+
+import (
+	"task/pkg/configuration"
+)
+
+func InitializeForTest() {
+	if internalLogger != nil {
+		return
+	}
+	Initialize(configuration.ConfigLogger{
+		LogLevel:    "trace",
+		LogSaveFile: false,
+	})
+}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -1,0 +1,5 @@
+package models
+
+const (
+	TaskIDNotFoundError = "TASK_ID_NOT_FOUND_ERROR"
+)


### PR DESCRIPTION
**Context:**
First, a new file has been added, containing the unique error code that callers must be aware of for translation purposes. Additionally, the repository interface has been implemented. Traditionally, this would involve persisting information in a database (that needs also the correct migrations); however, for testing simplicity, the information is currently stored in a map, allowing for quick retrieval and ease of testing. Please note that this approach does not retain data once the application is stopped.

**Previously:**
- PR 9: add service according to the task (pdf) (https://github.com/RachidEddahaPrivate/task-golang/pull/9) 

**In this PR:**
Add a new file housing a unique error code for caller awareness during translation. Simultaneously, the repository interface has been implemented, utilizing a map for information storage. This choice has been made to facilitate testing, allowing for quick retrieval and storage of necessary information. It's important to note that this approach does not preserve data once the application is stopped.

**Risk:**
There are no risk, since the repository is not connected.

**How to revert:**
To revert these changes, remove the files associated with the error codes and the repository interface implementation. 

**Testing:**
After the usual initializations, pass this implementation of the repository to the service, which will, in turn, be passed to the controller. Subsequently, register this controller within Echo. Now, initiate various calls to observe if the data are stored.